### PR TITLE
Reuse HttpClient instances. As mentioned in http://blogs.msdn.com/b/henr...

### DIFF
--- a/src/Q42.HueApi.NET/SSDPBridgeLocator.cs
+++ b/src/Q42.HueApi.NET/SSDPBridgeLocator.cs
@@ -123,6 +123,7 @@ namespace Q42.HueApi.NET
     // http://www.nerdblog.com/2012/10/a-day-with-philips-hue.html - description.xml retrieval
     private async Task<bool> IsHue(string discoveryUrl)
     {
+      // since this specifies timeout (and probably isn't called much), don't use shared client
       var http = new HttpClient { Timeout = TimeSpan.FromMilliseconds(2000) };
       try
       {

--- a/src/Q42.HueApi/HttpBridgeLocator.cs
+++ b/src/Q42.HueApi/HttpBridgeLocator.cs
@@ -24,6 +24,7 @@ namespace Q42.HueApi
 		/// <returns></returns>
     public async Task<IEnumerable<string>> LocateBridgesAsync(TimeSpan timeout)
     {
+      // since this specifies timeout (and probably isn't called much), don't use shared client
       HttpClient client = new HttpClient();
       client.Timeout = timeout;
 

--- a/src/Q42.HueApi/HueClient-Api.cs
+++ b/src/Q42.HueApi/HueClient-Api.cs
@@ -38,7 +38,7 @@ namespace Q42.HueApi
       obj["username"] = appKey;
       obj["devicetype"] = appName;
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
       var response = await client.PostAsync(new Uri(string.Format("http://{0}/api", _ip)), new StringContent(obj.ToString())).ConfigureAwait(false);
       var stringResponse = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 

--- a/src/Q42.HueApi/HueClient-Config.cs
+++ b/src/Q42.HueApi/HueClient-Config.cs
@@ -23,7 +23,7 @@ namespace Q42.HueApi
     {
       CheckInitialized();
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
 
       var response = await client.DeleteAsync(new Uri(string.Format("{0}config/whitelist/{1}", ApiBase, entry))).ConfigureAwait(false);
       var stringResponse = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -67,7 +67,7 @@ namespace Q42.HueApi
     {
       CheckInitialized();
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
       var stringResult = await client.GetStringAsync(new Uri(ApiBase)).ConfigureAwait(false);
 
       BridgeState jsonResult = DeserializeResult<BridgeState>(stringResult);
@@ -86,7 +86,7 @@ namespace Q42.HueApi
 
       string command = JsonConvert.SerializeObject(update, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore });
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
       var result = await client.PutAsync(new Uri(string.Format("{0}config", ApiBase)), new StringContent(command)).ConfigureAwait(false);
 
       string jsonResult = await result.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/src/Q42.HueApi/HueClient-Groups.cs
+++ b/src/Q42.HueApi/HueClient-Groups.cs
@@ -36,7 +36,7 @@ namespace Q42.HueApi
 
       string jsonString = JsonConvert.SerializeObject(jsonObj);
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
       //Create group with the lights we want to target
       var response = await client.PostAsync(new Uri(String.Format("{0}groups", ApiBase)), new StringContent(jsonString)).ConfigureAwait(false);
       var jsonResult = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -64,7 +64,7 @@ namespace Q42.HueApi
     {
       CheckInitialized();
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
       //Delete group 1
       var result =  await client.DeleteAsync(new Uri(ApiBase + string.Format("groups/{0}", groupId))).ConfigureAwait(false);
 
@@ -103,7 +103,7 @@ namespace Q42.HueApi
 
       CheckInitialized();
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
       var result = await client.PutAsync(new Uri(ApiBase + string.Format("groups/{0}/action", group)), new StringContent(command)).ConfigureAwait(false);
 
       string jsonResult = await result.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -120,7 +120,7 @@ namespace Q42.HueApi
     {
       CheckInitialized();
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
       string stringResult = await client.GetStringAsync(new Uri(String.Format("{0}groups", ApiBase))).ConfigureAwait(false);
 
       List<Group> results = new List<Group>();
@@ -154,7 +154,7 @@ namespace Q42.HueApi
     {
       CheckInitialized();
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
       string stringResult = await client.GetStringAsync(new Uri(String.Format("{0}groups/{1}", ApiBase, id))).ConfigureAwait(false);
 
 #if DEBUG
@@ -195,7 +195,7 @@ namespace Q42.HueApi
 
       string jsonString = JsonConvert.SerializeObject(jsonObj);
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
       var response = await client.PutAsync(new Uri(String.Format("{0}groups/{1}", ApiBase, id)), new StringContent(jsonString)).ConfigureAwait(false);
       var jsonResult = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 

--- a/src/Q42.HueApi/HueClient-Info.cs
+++ b/src/Q42.HueApi/HueClient-Info.cs
@@ -24,7 +24,7 @@ namespace Q42.HueApi
     {
       CheckInitialized();
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
       var result = await client.GetAsync(new Uri(String.Format("{0}info/timezones", ApiBase))).ConfigureAwait(false);
 
       var jsonResult = await result.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/src/Q42.HueApi/HueClient-Lights.cs
+++ b/src/Q42.HueApi/HueClient-Lights.cs
@@ -32,7 +32,7 @@ namespace Q42.HueApi
 
       CheckInitialized();
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
       string stringResult = await client.GetStringAsync(new Uri(String.Format("{0}lights/{1}", ApiBase, id))).ConfigureAwait(false);
 
 #if DEBUG
@@ -74,7 +74,7 @@ namespace Q42.HueApi
 
       string command = JsonConvert.SerializeObject(new { name = name});
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
       var result = await client.PutAsync(new Uri(String.Format("{0}lights/{1}", ApiBase, id)), new StringContent(command)).ConfigureAwait(false);
 
       var jsonResult = await result.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -135,7 +135,7 @@ namespace Q42.HueApi
 
         await lightList.ForEachAsync(_parallelRequests, async (lightId) =>
         {
-          HttpClient client = new HttpClient();
+          HttpClient client = HueClient.GetHttpClient();
           await client.PutAsync(new Uri(ApiBase + string.Format("lights/{0}/state", lightId)), new StringContent(command)).ConfigureAwait(false);
 
         }).ConfigureAwait(false);
@@ -168,7 +168,7 @@ namespace Q42.HueApi
     {
       CheckInitialized();
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
       var response = await client.PostAsync(new Uri(String.Format("{0}lights", ApiBase)), null).ConfigureAwait(false);
 
       var jsonResult = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -185,7 +185,7 @@ namespace Q42.HueApi
     {
       CheckInitialized();
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
       string stringResult = await client.GetStringAsync(new Uri(String.Format("{0}lights/new", ApiBase))).ConfigureAwait(false);
 
 #if DEBUG

--- a/src/Q42.HueApi/HueClient-Rules.cs
+++ b/src/Q42.HueApi/HueClient-Rules.cs
@@ -27,7 +27,7 @@ namespace Q42.HueApi
     {
       CheckInitialized();
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
       string stringResult = await client.GetStringAsync(new Uri(String.Format("{0}rules", ApiBase))).ConfigureAwait(false);
 
 #if DEBUG
@@ -70,7 +70,7 @@ namespace Q42.HueApi
 
       CheckInitialized();
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
       string stringResult = await client.GetStringAsync(new Uri(String.Format("{0}rules/{1}", ApiBase, id))).ConfigureAwait(false);
 
 #if DEBUG
@@ -120,7 +120,7 @@ namespace Q42.HueApi
 
       string jsonString = JsonConvert.SerializeObject(jsonObj);
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
       //Create group with the lights we want to target
       var response = await client.PostAsync(new Uri(String.Format("{0}rules", ApiBase)), new StringContent(jsonString)).ConfigureAwait(false);
       var jsonResult = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -160,7 +160,7 @@ namespace Q42.HueApi
 
       string jsonString = JsonConvert.SerializeObject(jsonObj);
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
       var response = await client.PutAsync(new Uri(String.Format("{0}rules/{1}", ApiBase, id)), new StringContent(jsonString)).ConfigureAwait(false);
 
       var jsonResult = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -178,7 +178,7 @@ namespace Q42.HueApi
     {
       CheckInitialized();
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
       var result = await client.DeleteAsync(new Uri(ApiBase + string.Format("rules/{0}", id))).ConfigureAwait(false);
 
       string jsonResult = await result.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/src/Q42.HueApi/HueClient-Scenes.cs
+++ b/src/Q42.HueApi/HueClient-Scenes.cs
@@ -28,7 +28,7 @@ namespace Q42.HueApi
     {
       CheckInitialized();
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
       string stringResult = await client.GetStringAsync(new Uri(String.Format("{0}scenes", ApiBase))).ConfigureAwait(false);
 
 #if DEBUG
@@ -77,7 +77,7 @@ namespace Q42.HueApi
 
       string jsonString = JsonConvert.SerializeObject(jsonObj);
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
       var response = await client.PutAsync(new Uri(String.Format("{0}scenes/{1}", ApiBase, id)), new StringContent(jsonString)).ConfigureAwait(false);
 
       var jsonResult = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -104,7 +104,7 @@ namespace Q42.HueApi
 
       string jsonCommand = JsonConvert.SerializeObject(command, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore });
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
       var response = await client.PutAsync(new Uri(String.Format("{0}scenes/{1}/lights/{1}/state", ApiBase, sceneId, lightId)), new StringContent(jsonCommand)).ConfigureAwait(false);
 
       var jsonResult = await response.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/src/Q42.HueApi/HueClient-Schedules.cs
+++ b/src/Q42.HueApi/HueClient-Schedules.cs
@@ -24,7 +24,7 @@ namespace Q42.HueApi
     {
       CheckInitialized();
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
       string stringResult = await client.GetStringAsync(new Uri(String.Format("{0}schedules", ApiBase))).ConfigureAwait(false);
 
       List<Schedule> results = new List<Schedule>();
@@ -58,7 +58,7 @@ namespace Q42.HueApi
     {
       CheckInitialized();
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
       string stringResult = await client.GetStringAsync(new Uri(String.Format("{0}schedules/{1}", ApiBase, id))).ConfigureAwait(false);
 
       Schedule schedule = DeserializeResult<Schedule>(stringResult);
@@ -81,7 +81,7 @@ namespace Q42.HueApi
 
       string command = JsonConvert.SerializeObject(schedule, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore });
      
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
 
       //Create schedule
       var result = await client.PostAsync(new Uri(ApiBase + "schedules"), new StringContent(command)).ConfigureAwait(false);
@@ -110,7 +110,7 @@ namespace Q42.HueApi
 
       string command = JsonConvert.SerializeObject(schedule, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore });
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
 
       //Create schedule
       var result = await client.PutAsync(new Uri(string.Format("{0}schedules/{1}", ApiBase, id)), new StringContent(command)).ConfigureAwait(false);
@@ -128,7 +128,7 @@ namespace Q42.HueApi
     /// <returns></returns>
     public async Task<HueResults> DeleteScheduleAsync(string id)
     {
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
       //Delete schedule
       var result = await client.DeleteAsync(new Uri(ApiBase + string.Format("schedules/{0}", id))).ConfigureAwait(false);
 

--- a/src/Q42.HueApi/HueClient-Sensors.cs
+++ b/src/Q42.HueApi/HueClient-Sensors.cs
@@ -28,7 +28,7 @@ namespace Q42.HueApi
     {
       CheckInitialized();
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
       string stringResult = await client.GetStringAsync(new Uri(String.Format("{0}sensors", ApiBase))).ConfigureAwait(false);
 
 #if DEBUG
@@ -64,7 +64,7 @@ namespace Q42.HueApi
 
       string sensorJson = JsonConvert.SerializeObject(sensor, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore });
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
 
       //Create schedule
       var result = await client.PostAsync(new Uri(String.Format("{0}sensors", ApiBase)), new StringContent(sensorJson)).ConfigureAwait(false);
@@ -89,7 +89,7 @@ namespace Q42.HueApi
     {
       CheckInitialized();
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
       var response = await client.PostAsync(new Uri(String.Format("{0}sensors", ApiBase)), null).ConfigureAwait(false);
 
       var jsonResult = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -107,7 +107,7 @@ namespace Q42.HueApi
     {
       CheckInitialized();
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
       string stringResult = await client.GetStringAsync(new Uri(String.Format("{0}sensors/new", ApiBase))).ConfigureAwait(false);
 
 #if DEBUG
@@ -155,7 +155,7 @@ namespace Q42.HueApi
 
       CheckInitialized();
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
       string stringResult = await client.GetStringAsync(new Uri(String.Format("{0}sensors/{1}", ApiBase, id))).ConfigureAwait(false);
 
 #if DEBUG
@@ -201,7 +201,7 @@ namespace Q42.HueApi
 
       string jsonString = JsonConvert.SerializeObject(jsonObj);
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
 
       //Create schedule
       var result = await client.PutAsync(new Uri(string.Format("{0}sensors/{1}", ApiBase, id)), new StringContent(jsonString)).ConfigureAwait(false);
@@ -231,7 +231,7 @@ namespace Q42.HueApi
 
       string jsonString = JsonConvert.SerializeObject(config);
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
 
       //Create schedule
       var result = await client.PutAsync(new Uri(string.Format("{0}sensors/{1}/config", ApiBase, id)), new StringContent(jsonString)).ConfigureAwait(false);
@@ -255,7 +255,7 @@ namespace Q42.HueApi
 
       string jsonString = JsonConvert.SerializeObject(state);
 
-      HttpClient client = new HttpClient();
+      HttpClient client = HueClient.GetHttpClient();
 
       //Create schedule
       var result = await client.PutAsync(new Uri(string.Format("{0}sensors/{1}/state", ApiBase, id)), new StringContent(jsonString)).ConfigureAwait(false);

--- a/src/Q42.HueApi/HueClient.cs
+++ b/src/Q42.HueApi/HueClient.cs
@@ -87,6 +87,16 @@ namespace Q42.HueApi
       IsInitialized = true;
     }
 
+    [ThreadStatic]
+    private static HttpClient _httpClient;
+    public static HttpClient GetHttpClient()
+    {
+      // return per-thread HttpClient
+      if (_httpClient == null)
+        _httpClient = new HttpClient();
+      return _httpClient;
+    }
+
     /// <summary>
     /// Check if the HueClient is initialized
     /// </summary>


### PR DESCRIPTION
...ikn/archive/2012/02/11/httpclient-is-here.aspx and http://stackoverflow.com/questions/15705092/do-httpclient-and-httpclienthandler-have-to-be-disposed , HttpClient is meant to be a long-lived instance. When it is created new for each request, if lots of requests are occurring, then a lot of AggregateExceptions containing HttpRequestExceptions or SocketExceptions occur (often one every few minutes). With long-lived instances, errors are much rarer (often once per hour or less). Note that I first tried disposing the HttpClient instances promptly (hoping that prompt cleanup would avoid any underlying resource saturation issues), but this did not improve stability.
