### PR TITLE
Updated Readme bridge registration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Before you can communicate with the Philips Hue Bridge, you need to find the bri
 Register your application
 	
 	HueClient client = new HueClient("ip");
-	client.RegisterAsync("mypersonalappname", "mypersonalappkey");
+	var appKey = await client.RegisterAsync("mypersonalappname", "mydevicename");
+	//Save the app key for later use
 	
 If you already registered an appname, you can initialize the HueClient with the app's key:	
 


### PR DESCRIPTION
The example for registering your app at the bridge seemed outdated. As the api-doc already explains, the register call now returns the secret key for the app and you register your app with app and device names instead of passing a key, so the example has been updated to reflect that.