### PR TITLE
Added Xamarin support to the PCL nuspec

### DIFF
--- a/src/Q42.HueApi/Q42.HueApi.nuspec
+++ b/src/Q42.HueApi/Q42.HueApi.nuspec
@@ -28,8 +28,8 @@
     </dependencies>  
   </metadata>
   <files>
-		<file src="..\Q42.HueApi\bin\Release\Q42.HueApi.dll" target="lib\portable-net45+wp80+win81+wpa81" />
-		<file src="..\Q42.HueApi\bin\Release\Q42.HueApi.XML" target="lib\portable-net45+wp80+win81+wpa81" />
+		<file src="..\Q42.HueApi\bin\Release\Q42.HueApi.dll" target="lib\portable-net45+win+wpa81+wp80+MonoAndroid10+MonoTouch10" />
+		<file src="..\Q42.HueApi\bin\Release\Q42.HueApi.XML" target="lib\portable-net45+win+wpa81+wp80+MonoAndroid10+MonoTouch10" />
   </files>
 </package>
 


### PR DESCRIPTION
Added more PCL configurations in the nuspec file, to enable MonoTouch10
(iOS), and MonoAndroid10 (Android)