### PR TITLE
Update SSDPBridgeLocator.cs

### DIFF
--- a/src/Q42.HueApi.NET/SSDPBridgeLocator.cs
+++ b/src/Q42.HueApi.NET/SSDPBridgeLocator.cs
@@ -75,7 +75,7 @@ namespace Q42.HueApi.NET
           {
             var receivedString = Encoding.UTF8.GetString(response);
 
-            var location = receivedString.Substring(receivedString.ToLower().IndexOf("location:", System.StringComparison.Ordinal) + 9);
+            var location = receivedString.Substring(receivedString.IndexOf("LOCATION:", System.StringComparison.Ordinal) + 9);
             receivedString = location.Substring(0, location.IndexOf("\r", System.StringComparison.Ordinal)).Trim();
 
             _discoveredDevices.Add(receivedString);


### PR DESCRIPTION
If computer language is Turkish, "LOCATION" is converted to "locatıon" instead of "location". Thus, not matching Substring() function.

The same problem may exist also for some other languages too. Please see http://www.fileformat.info/info/unicode/char/0049/index.htm

Better not convert to lower case
Or use System.StringComparison.InvariantCultureIgnoreCase.