### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,5 +132,5 @@ Xbox One
 Windows Desktop
 * [CastleOS](http://www.CastleOS.com/)
 
-MONO
-* [Command Line Tool](http://www.everyhue.com/vanilla/discussion/1061)
+Command Line Tools - Windows, Linux (x64 & ARM) and Windows 10 IOT (ARM)
+* [Command Line Tools](https://github.com/DigitalNut/HueCmdNetCore)


### PR DESCRIPTION
Updated command line tools section. Old Mono command line link was dead, now points to a new command line tool that works under Windows & Linux.