### PR TITLE
Update to official BouncyCastle package

### DIFF
--- a/src/Q42.HueApi.Streaming/Q42.HueApi.Streaming.csproj
+++ b/src/Q42.HueApi.Streaming/Q42.HueApi.Streaming.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BouncyCastle.NetCore" Version="1.8.5" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.8.5.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Portable.BouncyCastle is the official version of BC that works on .NET Core/.NET Standard.