### PR TITLE
Bridge locator : Add cancellationToken interface and Improve SsdpBridgeLocator

### DIFF
--- a/src/Q42.HueApi.Tests/BridgeDiscoveryTests.cs
+++ b/src/Q42.HueApi.Tests/BridgeDiscoveryTests.cs
@@ -14,10 +14,7 @@ namespace Q42.HueApi.Tests
     {
       IBridgeLocator locator = new HttpBridgeLocator();
 
-      var bridgeIPs = await locator.LocateBridgesAsync(TimeSpan.FromSeconds(5));
-
-      Assert.IsNotNull(bridgeIPs);
-      Assert.IsTrue(bridgeIPs.Any());
+      await TestBridgeLocatorWithTimeout(locator, TimeSpan.FromSeconds(5));
     }
 
     [TestMethod]
@@ -25,10 +22,23 @@ namespace Q42.HueApi.Tests
     {
       IBridgeLocator locator = new SsdpBridgeLocator();
 
-      var bridgeIPs = await locator.LocateBridgesAsync(TimeSpan.FromSeconds(5));
+      await TestBridgeLocatorWithTimeout(locator, TimeSpan.FromSeconds(5));
+    }
 
-      Assert.IsNotNull(bridgeIPs);
-      Assert.IsTrue(bridgeIPs.Any());
+    private async Task TestBridgeLocatorWithTimeout(IBridgeLocator locator, TimeSpan timeout)
+    {
+      var startTime = DateTime.Now;
+      var bridgeIPs = await locator.LocateBridgesAsync(timeout);
+
+      Assert.IsTrue(
+        DateTime.Now.Subtract(startTime).Subtract(timeout) < TimeSpan.FromMilliseconds(250),
+        "Must complete inside the timeout specified (plus 250 ms)");
+
+      Assert.IsNotNull(bridgeIPs,
+        "Must return list");
+
+      Assert.IsTrue(bridgeIPs.Any(),
+        "Must find bridges");
     }
   }
 }

--- a/src/Q42.HueApi/Extensions/IPAddressExtensions.cs
+++ b/src/Q42.HueApi/Extensions/IPAddressExtensions.cs
@@ -1,0 +1,75 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace Q42.HueApi.Extensions
+{
+  /// <summary>
+  /// IPAddress Helpers
+  /// </summary>
+  internal static class IPAddressExtensions
+  {
+    /// <summary>
+    /// Check if given IPv4 is a link-local (auto configuration) address (according to RFC3927)
+    /// </summary>
+    /// <remarks>https://tools.ietf.org/html/rfc3927</remarks>
+    /// <param name="ip">The IPv4</param>
+    /// <returns>True if link-local, false otherwise</returns>
+    public static bool IsIPv4LinkLocal(this IPAddress ip)
+    {
+      if (ip.AddressFamily != AddressFamily.InterNetwork)
+      {
+        // Not an IPv4, simply return false
+        return false;
+      }
+
+      return ip.ToString().StartsWith("169.254.");
+    }
+
+    /// <summary>
+    /// Check if given IP is a loopback
+    /// <para>This is just a helper extension around the static method IPAddress.IsLoopback</para>
+    /// </summary>
+    /// <param name="ip">The IP</param>
+    /// <returns>True if loopback, False otherwise</returns>
+    public static bool IsLoopback(this IPAddress ip)
+    {
+      return IPAddress.IsLoopback(ip);
+    }
+
+    /// <summary>
+    /// Check if given IPv4 is in private range (according to RFC1918)
+    /// </summary>
+    /// <remarks>https://tools.ietf.org/html/rfc1918</remarks>
+    /// <param name="ip">The IPv4</param>
+    /// <returns>True if private, false otherwise</returns>
+    public static bool IsIPv4Private(this IPAddress ip)
+    {
+      if (ip.AddressFamily != AddressFamily.InterNetwork)
+      {
+        // Not an IPv4, simply return false
+        return false;
+      }
+
+      byte[] bytes = ip.GetAddressBytes();
+
+      switch (bytes[0])
+      {
+        // 10.0.0.0 - 10.255.255.255 (10/8 prefix)
+        case 10:
+          return true;
+
+        // 172.16.0.0 - 172.31.255.255 (172.16/12 prefix)
+        case 172:
+          return bytes[1] < 32 && bytes[1] >= 16;
+
+        // 192.168.0.0 - 192.168.255.255 (192.168/16 prefix)
+        case 192:
+          return bytes[1] == 168;
+
+        // Others
+        default:
+          return false;
+      }
+    }
+  }
+}

--- a/src/Q42.HueApi/HttpBridgeLocator.cs
+++ b/src/Q42.HueApi/HttpBridgeLocator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Q42.HueApi.Interfaces;
@@ -19,20 +20,44 @@ namespace Q42.HueApi
     /// <summary>
     /// Locate bridges
     /// </summary>
-    /// <param name="timeout"></param>
-    /// <returns></returns>
+    /// <param name="timeout">Timeout before stopping the search</param>
+    /// <returns>List of bridge IPs found</returns>
     public async Task<IEnumerable<LocatedBridge>> LocateBridgesAsync(TimeSpan timeout)
     {
-      // since this specifies timeout (and probably isn't called much), don't use shared client
+      if (timeout <= TimeSpan.Zero)
+      {
+        throw new ArgumentException("Timeout value must be greater than zero.", nameof(timeout));
+      }
+
+      using (CancellationTokenSource cancelSource = new CancellationTokenSource(timeout))
+      {
+        return await LocateBridgesAsync(cancelSource.Token);
+      }
+    }
+
+    /// <summary>
+    /// Locate bridges
+    /// </summary>
+    /// <param name="cancellationToken">Token to cancel the search</param>
+    /// <returns>List of bridge IPs found</returns>
+    public async Task<IEnumerable<LocatedBridge>> LocateBridgesAsync(CancellationToken cancellationToken)
+    {
       using (HttpClient client = new HttpClient())
       {
-        client.Timeout = timeout;
+        var response = await client.GetAsync(NuPnPUrl, cancellationToken).ConfigureAwait(false);
 
-        string response = await client.GetStringAsync(NuPnPUrl).ConfigureAwait(false);
+        if (response.IsSuccessStatusCode && !cancellationToken.IsCancellationRequested)
+        {
+          string content = await response.Content.ReadAsStringAsync();
 
-        NuPnPResponse[] responseModel = JsonConvert.DeserializeObject<NuPnPResponse[]>(response);
+          NuPnPResponse[] responseModel = JsonConvert.DeserializeObject<NuPnPResponse[]>(content);
 
-        return responseModel.Select(x => new LocatedBridge() { BridgeId = x.Id, IpAddress = x.InternalIpAddress }).ToList();
+          return responseModel.Select(x => new LocatedBridge() { BridgeId = x.Id, IpAddress = x.InternalIpAddress }).ToList();
+        }
+        else
+        {
+          return new List<LocatedBridge>();
+        }
       }
     }
   }

--- a/src/Q42.HueApi/Interfaces/IBridgeLocator.cs
+++ b/src/Q42.HueApi/Interfaces/IBridgeLocator.cs
@@ -1,9 +1,8 @@
-using Q42.HueApi.Models.Bridge;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
+using Q42.HueApi.Models.Bridge;
 
 namespace Q42.HueApi.Interfaces
 {
@@ -13,10 +12,17 @@ namespace Q42.HueApi.Interfaces
   public interface IBridgeLocator
   {
     /// <summary>
-    /// Returns list of bridge IPs
+    /// Locate bridges
     /// </summary>
-    /// <param name="timeout"></param>
-    /// <returns></returns>
+    /// <param name="timeout">Timeout before stopping the search</param>
+    /// <returns>List of bridge IPs found</returns>
     Task<IEnumerable<LocatedBridge>> LocateBridgesAsync(TimeSpan timeout);
+
+    /// <summary>
+    /// Locate bridges
+    /// </summary>
+    /// <param name="cancellationToken">Token to cancel the search</param>
+    /// <returns>List of bridge IPs found</returns>
+    Task<IEnumerable<LocatedBridge>> LocateBridgesAsync(CancellationToken cancellationToken);
   }
 }

--- a/src/Q42.HueApi/SsdpBridgeLocator.cs
+++ b/src/Q42.HueApi/SsdpBridgeLocator.cs
@@ -4,11 +4,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.NetworkInformation;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Q42.HueApi.Extensions;
 using Q42.HueApi.Interfaces;
 using Q42.HueApi.Models.Bridge;
 
@@ -22,19 +25,18 @@ namespace Q42.HueApi
   {
     private readonly IPAddress multicastAddress = IPAddress.Parse("239.255.255.250");
     private const int multicastPort = 1900;
-    private const int unicastPort = 1901;
 
     private const string messageHeader = "M-SEARCH * HTTP/1.1";
     private const string messageHost = "HOST: 239.255.255.250:1900";
     private const string messageMan = "MAN: \"ssdp:discover\"";
-    private const string messageMx = "MX: 8";
-    private const string messageSt = "ST:SsdpSearch:all";
+    private const string messageMx = "MX: 1";
+    private const string messageSt = "ST: SsdpSearch:all";
 
     private readonly Regex ssdpResponseLocationRegex = new Regex(@"LOCATION: *(http.+?/description\.xml)\r", RegexOptions.IgnoreCase);
     private static readonly Regex xmlResponseCheckHueRegex = new Regex(@"Philips hue bridge", RegexOptions.IgnoreCase);
     private static readonly Regex xmlResponseSerialNumberRegex = new Regex(@"<serialnumber>(.+?)</serialnumber>", RegexOptions.IgnoreCase);
 
-    private readonly byte[] broadcastMessage = Encoding.UTF8.GetBytes(
+    private readonly byte[] ssdpDiscoveryMessage = Encoding.UTF8.GetBytes(
         string.Format("{1}{0}{2}{0}{3}{0}{4}{0}{5}{0}{0}",
                       "\r\n",
                       messageHeader,
@@ -73,15 +75,43 @@ namespace Q42.HueApi
     {
       _discoveredBridges = new ConcurrentDictionary<string, LocatedBridge>();
 
-      using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
-      {
-        // Configure socket
-        socket.Bind(new IPEndPoint(IPAddress.Any, unicastPort));
-        socket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership, new MulticastOption(multicastAddress, IPAddress.Any));
-        socket.SendTo(broadcastMessage, 0, broadcastMessage.Length, SocketFlags.None, new IPEndPoint(multicastAddress, multicastPort));
+      List<Socket> socketList = new List<Socket>();
 
-        // Spin up a new thread to handle socket responses
-        new Thread(() => ListenSocketResponseAsync(socket)).Start();
+      try
+      {
+#if !NET45
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+#endif
+          // On Windows, using INADDR_ANY could lead to issue due to the Windows SSDP Discovery service throttling multicast packets
+          // See https://stackoverflow.com/q/32682969/8861729
+          // So we will bind directly to all network interface having a private IPs
+          socketList = NetworkInterface.GetAllNetworkInterfaces()
+            // Keep only connected interfaces
+            .Where(itf => itf.OperationalStatus == OperationalStatus.Up)
+            // Retrieve first unicast address on each interface
+            .Select(itf => itf.GetIPProperties().UnicastAddresses.First())
+            // Keep only private IPv4
+            .Where(info => !info.Address.IsLoopback() && !info.Address.IsIPv4LinkLocal() && info.Address.IsIPv4Private())
+            // Create socket for each address remaining (and asking for a random available port)
+            .Select(info => CreateSocketForSSDP(new IPEndPoint(info.Address, 0)))
+            .ToList();
+#if !NET45
+        }
+        else
+        {
+          // On other plateform, simply use INADDR_ANY (and asking for a random available port)
+          socketList.Add(CreateSocketForSSDP(new IPEndPoint(IPAddress.Any, 0)));
+        }
+#endif
+
+        foreach (Socket socket in socketList)
+        {
+          // Send SSDP discovery message
+          socket.SendTo(ssdpDiscoveryMessage, SocketFlags.None, new IPEndPoint(multicastAddress, multicastPort));
+          // Spin up a new thread to listen to this socket
+          new Thread(() => ListenSocket(socket)).Start();
+        }
 
         try
         {
@@ -92,19 +122,45 @@ namespace Q42.HueApi
         {
           // Cancellation requested
         }
-
-        // Force close the connection (will end the thread)
-        socket.Close();
+      }
+      finally
+      {
+        // Close socket (which will end thread) then dispose unmanaged resource
+        foreach (Socket socket in socketList)
+        {
+          socket.Close();
+          socket.Dispose();
+        }
       }
 
       return _discoveredBridges.Select(x => x.Value).ToList();
     }
 
     /// <summary>
+    /// Create a multicast socket for SSDP
+    /// </summary>
+    /// <param name="endpointToBind">the endpoint to bind to</param>
+    private Socket CreateSocketForSSDP(IPEndPoint endpointToBind)
+    {
+      Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+
+      // Socket config : allow address reuse
+      socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+
+      // Socket config : bind to all interface and to a port (if 0, ask for a free one)
+      socket.Bind(endpointToBind);
+
+      // Socket config : Add Multicast address membership to be able to send to it
+      socket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership, new MulticastOption(multicastAddress, IPAddress.Any));
+
+      return socket;
+    }
+
+    /// <summary>
     /// Listen to response on socket
     /// </summary>
     /// <param name="socket">The socket to listen to</param>
-    private void ListenSocketResponseAsync(Socket socket)
+    private void ListenSocket(Socket socket)
     {
       try
       {


### PR DESCRIPTION
Hello,

Continuing the work on #198 

This PR brings two enhancements:
1. **Add a new interface to the `IBridgeLocator` accepting a cancellationToken.**
    ```cs
    Task<IEnumerable<LocatedBridge>> LocateBridgesAsync(CancellationToken cancellationToken)
    ```
    It allows users to provide a cancel mechanism different from a simple timeout.
    As a matter of facts, the old signature with the timeout simply use a cancellationToken with a timeout!
1. **Improve the `SsdpBridgeLocator` reliability on Windows**
   After a lot of tests in our lab, it became quite clear that the SSDP protocol was not reliable. Sometimes it would find instantly a bridge, sometimes not. Using Wireshark, we found out that when the bridge wasn't found, it was because the system actually never sent the discovery packet. It was baffling.
   After some searching, we found [someone talking about a very specific issue](https://stackoverflow.com/q/32682969/8861729) on Windows linked to the SSDP Discovery Service.
   As suggested, we tried binding the socket directly to the interface IP (instead of all interface using `Any`) and it worked flawlessly every time!
   So this is why we have to check for the OS, and perform a lookup on all private interfaces in order to use them to bind.
   I've also modified the discovery message by setting `MX: 1` which is suppose to be the max delay to reply for the device.

As a side note, I am also working on a `LocalNetworkBridgeLocator` (IP lookup) for which a different PR will be provided. It will also make use of the new `IPAddressExtensions`.

If I find the time, I will also look into the MDNS protocol since it is the recommended approach by Philips. I'll keep you posted.

Of course, I am open to code review / remarks.