### PR TITLE
Add MdnsBridgeLocator 

### DIFF
--- a/src/Q42.HueApi.Tests/BridgeDiscoveryTests.cs
+++ b/src/Q42.HueApi.Tests/BridgeDiscoveryTests.cs
@@ -35,6 +35,14 @@ namespace Q42.HueApi.Tests
       await TestBridgeLocatorWithTimeout(locator, TimeSpan.FromSeconds(30));
     }
 
+    [TestMethod]
+    public async Task TestMdnsBridgeLocator()
+    {
+      IBridgeLocator locator = new MdnsBridgeLocator();
+
+      await TestBridgeLocatorWithTimeout(locator, TimeSpan.FromSeconds(5));
+    }
+
     private async Task TestBridgeLocatorWithTimeout(IBridgeLocator locator, TimeSpan timeout)
     {
       var startTime = DateTime.Now;

--- a/src/Q42.HueApi/MUdpBasedBridgeLocator.cs
+++ b/src/Q42.HueApi/MUdpBasedBridgeLocator.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Q42.HueApi.Extensions;
+using Q42.HueApi.Models.Bridge;
+
+namespace Q42.HueApi
+{
+  /// <summary>
+  /// Base class for bridge locator based on Multicast UDP discovery
+  /// </summary>
+  public abstract class MUdpBasedBridgeLocator : BridgeLocator
+  {
+    /// <summary>
+    /// Locate bridges by sending a specific multicast packet and listening to any reply
+    /// <para>
+    /// The multicast packet is sent every second and any endpoint responding is investigated to see if it is a Hue Bridge</para>
+    /// </summary>
+    /// <param name="multicastAddress">Multicast address to send to</param>
+    /// <param name="multicastPort">Multicast port to send to</param>
+    /// <param name="localPort">Local port to send from and listen to</param>
+    /// <param name="discoveryMessageContent">The content to send</param>
+    /// <param name="cancellationToken">Token to cancel the search</param>
+    /// <returns>List of bridge IPs found</returns>
+    protected async Task<IEnumerable<LocatedBridge>> LocateBridgesAsync(
+      IPAddress multicastAddress, int multicastPort, int localPort, byte[] discoveryMessageContent, CancellationToken cancellationToken)
+    {
+      var discoveredBridges = new ConcurrentDictionary<string, LocatedBridge>();
+
+      // We will bind to all network interfaces having a private IPv4
+      List<Socket> socketList = NetworkInterfaceExtensions.GetAllUpNetworkInterfacesFirstPrivateIPv4()
+        // Create socket for each address remaining (and asking for a random available port)
+        .Select(info => CreateSocketForMulticastUDPIPv4(new IPEndPoint(info.Address, localPort), multicastAddress))
+        .ToList();
+
+      try
+      {
+        foreach (Socket socket in socketList)
+        {
+          // Spin up a new thread to listen to this socket
+          new Thread(() => ListenSocketAndCheckEveryEndpoint(socket, discoveredBridges)).Start();
+        }
+
+        do
+        {
+          // Send multicast discovery message for each socket
+          foreach (Socket socket in socketList)
+          {
+            socket.SendTo(discoveryMessageContent, SocketFlags.None, new IPEndPoint(multicastAddress, multicastPort));
+          }
+
+          // Wait 1 seconds (can be shorter if cancelled)
+          await Task.Delay(TimeSpan.FromMilliseconds(1000), cancellationToken);
+        }
+        while (!cancellationToken.IsCancellationRequested);
+      }
+      catch (TaskCanceledException)
+      {
+        // Cancellation requested
+      }
+      finally
+      {
+        // Close socket (which will end thread) then dispose unmanaged resource
+        foreach (Socket socket in socketList)
+        {
+          socket.Close();
+          socket.Dispose();
+        }
+      }
+
+      return discoveredBridges.Select(x => x.Value).ToList();
+    }
+
+    /// <summary>
+    /// Create a socket for multicast send/receive
+    /// </summary>
+    /// <param name="localEndpoint">the local endpoint to use</param>
+    /// <param name="multicastGroupAddress">the multicast group</param>
+    private static Socket CreateSocketForMulticastUDPIPv4(IPEndPoint localEndpoint, IPAddress multicastGroupAddress)
+    {
+      // Create an IPv4 UDP socket
+      Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+
+      // Allow address reuse
+      socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+
+      // Bind to all interface and to a port (if 0, ask for a free one)
+      socket.Bind(localEndpoint);
+
+      // Set TTL to 1: it will stays on the local network
+      socket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.MulticastTimeToLive, 1);
+
+      // Join Multicast group
+      socket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership,
+        new MulticastOption(multicastGroupAddress, localEndpoint.Address));
+
+      return socket;
+    }
+
+    /// <summary>
+    /// Listen to any response on a socket and check if responding IP is a Hue Bridge
+    /// </summary>
+    /// <param name="socket">The socket to listen to</param>
+    /// <param name="discoveredBridges">The dictionary to fill with located bridges</param>
+    private static void ListenSocketAndCheckEveryEndpoint(Socket socket, ConcurrentDictionary<string, LocatedBridge> discoveredBridges)
+    {
+      try
+      {
+        var ipSeen = new List<string>();
+        var socketAddress = ((IPEndPoint)socket.LocalEndPoint).Address;
+
+        while (true)
+        {
+          var responseRawBuffer = new byte[8000];
+          EndPoint responseEndPoint = new IPEndPoint(IPAddress.Any, 0);
+
+          // Blocking call until something is received
+          socket.ReceiveFrom(responseRawBuffer, ref responseEndPoint);
+
+          // We received a response
+          try
+          {
+            // Get IP address
+            IPAddress responseIpAddress = ((IPEndPoint)responseEndPoint).Address;
+
+            if (!socketAddress.Equals(responseIpAddress) && !ipSeen.Contains(responseIpAddress.ToString()))
+            {
+              // Try decode response as UTF8
+              var responseBody = Encoding.UTF8.GetString(responseRawBuffer);
+
+              if (!string.IsNullOrWhiteSpace(responseBody))
+              {
+                // Spin up a new thread to handle this specific response so we can continue waiting for response
+                new Thread(() =>
+                {
+                  try
+                  {
+                    // Check if it's a Hue Bridge
+                    string serialNumber = CheckHueDescriptor(responseIpAddress, TimeSpan.FromMilliseconds(1000)).Result;
+
+                    if (!string.IsNullOrWhiteSpace(serialNumber))
+                    {
+                      discoveredBridges.TryAdd(responseIpAddress.ToString(), new LocatedBridge()
+                      {
+                        IpAddress = responseIpAddress.ToString(),
+                        BridgeId = serialNumber,
+                      });
+                    }
+                    else
+                    {
+                      // Not a valid S/N
+                    }
+                  }
+                  catch
+                  {
+                    // Something went wrong, ignore...
+                  }
+                }).Start();
+
+                // Add this ip to local list, so we won't start other thread for it
+                ipSeen.Add(responseIpAddress.ToString());
+              }
+              else
+              {
+                // Not a valid response
+              }
+            }
+            else
+            {
+              // IP already seen
+            }
+          }
+          catch
+          {
+            // Something went wrong when parsing the response. Ignore it.
+          }
+        }
+      }
+      catch
+      {
+        // Socket connection closed, this will terminate the thread
+      }
+    }
+  }
+}

--- a/src/Q42.HueApi/MdnsBridgeLocator.cs
+++ b/src/Q42.HueApi/MdnsBridgeLocator.cs
@@ -1,0 +1,95 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Q42.HueApi.Models.Bridge;
+
+namespace Q42.HueApi
+{
+  /// <summary>
+  /// Uses M-DNS protocol to locate all Hue Bridge accross the network
+  /// </summary>
+  /// <remarks>https://developers.meethue.com/develop/application-design-guidance/hue-bridge-discovery</remarks>
+  public class MdnsBridgeLocator : MUdpBasedBridgeLocator
+  {
+    /// <summary>
+    /// Multicast group for MDNS Protocol
+    /// </summary>
+    private readonly IPAddress ssdpMulticastAddress = IPAddress.Parse("224.0.0.251");
+
+    /// <summary>
+    /// Multicast port for sending MDNS discovery message
+    /// </summary>
+    private const int mdnsMulticastPort = 5353;
+
+    /// <summary>
+    /// Local port to use to listen to response (same as sending)
+    /// </summary>
+    private const int mdnsLocalPort = mdnsMulticastPort;
+
+    /// <summary>
+    /// MDNS discovery message to send
+    /// </summary>
+    private readonly byte[] mdnsDiscoveryMessage = BuildMDNSMessage(
+      "_hue._tcp.local",  // Standard official service name
+      "_hap._tcp.local",  // Old service name
+      "Philips-hue.local" // Old service name
+    );
+
+    /// <summary>
+    /// Locate bridges
+    /// </summary>
+    /// <param name="cancellationToken">Token to cancel the search</param>
+    /// <returns>List of bridge IPs found</returns>
+    public override async Task<IEnumerable<LocatedBridge>> LocateBridgesAsync(CancellationToken cancellationToken)
+    {
+      return await LocateBridgesAsync(ssdpMulticastAddress, mdnsMulticastPort, mdnsLocalPort, mdnsDiscoveryMessage, cancellationToken);
+    }
+
+    /// <summary>
+    /// Build a MDNS message with a list of queries (= services) to search for
+    /// </summary>
+    /// <remarks>MDNS specs: https://tools.ietf.org/html/rfc6762 </remarks>
+    /// <remarks>DNS specs: https://tools.ietf.org/html/rfc1035 </remarks>
+    /// <param name="queries">List of query to search for</param>
+    /// <returns>The raw message content (bytes)</returns>
+    private static byte[] BuildMDNSMessage(params string[] queries)
+    {
+      var bytes = new List<byte>();
+
+      // Build M-DNS Header
+      bytes.AddRange(new byte[] { 0x00, 0x00 });  // Transaction ID = None
+      bytes.AddRange(new byte[] { 0x01, 0x00 });  // Standard query with Recursion
+      bytes.AddRange(new byte[] { 0x00, (byte)queries.Length });  // Number of Queries
+      bytes.AddRange(new byte[] { 0x00, 0x00 });  // Answer Resource Records = None
+      bytes.AddRange(new byte[] { 0x00, 0x00 });  // Authority Resource Records = None
+      bytes.AddRange(new byte[] { 0x00, 0x00 });  // Additional Resource Records = None
+
+      // Build M-DNS Queries
+      foreach (var query in queries)
+      {
+        // Each part of the query FQDN is preceded with a byte specifying the length
+        // The dot is not actually written
+        bytes.AddRange(query.Split('.')
+          .Select(part => Encoding.UTF8.GetBytes(part).ToList())
+          .SelectMany(partBytes =>
+          {
+            // Insert the length in front
+            partBytes.Insert(0, (byte)partBytes.Count);
+            return partBytes;
+          }));
+
+        // Add NULL terminator at the end
+        bytes.Add(0x00);
+
+        // Add query configuration
+        bytes.AddRange(new byte[] { 0x00, 0xFF }); // QTYPE = ANY
+        bytes.AddRange(new byte[] { 0x80, 0xFF }); // UNICAST-RESPONSE + QCLASS = ANY
+      }
+
+      return bytes.ToArray();
+    }
+  }
+}

--- a/src/Q42.HueApi/SsdpBridgeLocator.cs
+++ b/src/Q42.HueApi/SsdpBridgeLocator.cs
@@ -1,14 +1,8 @@
-using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Net.Sockets;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Q42.HueApi.Extensions;
 using Q42.HueApi.Models.Bridge;
 
 namespace Q42.HueApi
@@ -17,27 +11,34 @@ namespace Q42.HueApi
   /// Uses SSDP protocol to locate all Hue Bridge accross the network
   /// </summary>
   /// <remarks>https://developers.meethue.com/develop/application-design-guidance/hue-bridge-discovery</remarks>
-  public class SsdpBridgeLocator : BridgeLocator
+  public class SsdpBridgeLocator : MUdpBasedBridgeLocator
   {
-    private readonly IPAddress multicastAddress = IPAddress.Parse("239.255.255.250");
-    private const int multicastPort = 1900;
+    /// <summary>
+    /// Multicast group for SSDP Protocol
+    /// </summary>
+    private readonly IPAddress ssdpMulticastAddress = IPAddress.Parse("239.255.255.250");
 
-    private const string messageHeader = "M-SEARCH * HTTP/1.1";
-    private const string messageHost = "HOST: 239.255.255.250:1900";
-    private const string messageMan = "MAN: \"ssdp:discover\"";
-    private const string messageMx = "MX: 1";
-    private const string messageSt = "ST: SsdpSearch:all";
+    /// <summary>
+    /// Multicast port for sending SSDP discovery message
+    /// </summary>
+    private const int ssdpMulticastPort = 1900;
 
+    /// <summary>
+    /// Local port to use to listen to response (0 = use any free port available)
+    /// </summary>
+    private const int ssdpLocalPort = 0;
+
+    /// <summary>
+    /// SSDP discovery message to send
+    /// </summary>
     private readonly byte[] ssdpDiscoveryMessage = Encoding.UTF8.GetBytes(
         string.Format("{1}{0}{2}{0}{3}{0}{4}{0}{5}{0}{0}",
                       "\r\n",
-                      messageHeader,
-                      messageHost,
-                      messageMan,
-                      messageMx,
-                      messageSt));
-
-    private ConcurrentDictionary<string, LocatedBridge> _discoveredBridges;
+                      "M-SEARCH * HTTP/1.1",
+                      $"HOST: 239.255.255.250:1900",
+                      "MAN: \"ssdp:discover\"",
+                      "MX: 1",
+                      "ST: SsdpSearch:all"));
 
     /// <summary>
     /// Locate bridges
@@ -46,171 +47,7 @@ namespace Q42.HueApi
     /// <returns>List of bridge IPs found</returns>
     public override async Task<IEnumerable<LocatedBridge>> LocateBridgesAsync(CancellationToken cancellationToken)
     {
-      _discoveredBridges = new ConcurrentDictionary<string, LocatedBridge>();
-
-      List<Socket> socketList = new List<Socket>();
-
-      try
-      {
-#if !NET45
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-#endif
-          // On Windows, using INADDR_ANY could lead to issue due to the Windows SSDP Discovery service throttling multicast packets
-          // See https://stackoverflow.com/q/32682969/8861729
-          // So we will bind directly to all network interface having a private IPs
-          socketList = NetworkInterfaceExtensions.GetAllUpNetworkInterfacesFirstPrivateIPv4()
-            // Create socket for each address remaining (and asking for a random available port)
-            .Select(info => CreateSocketForSSDP(new IPEndPoint(info.Address, 0)))
-            .ToList();
-#if !NET45
-        }
-        else
-        {
-          // On other plateform, simply use INADDR_ANY (and asking for a random available port)
-          socketList.Add(CreateSocketForSSDP(new IPEndPoint(IPAddress.Any, 0)));
-        }
-#endif
-
-        foreach (Socket socket in socketList)
-        {
-          // Send SSDP discovery message
-          socket.SendTo(ssdpDiscoveryMessage, SocketFlags.None, new IPEndPoint(multicastAddress, multicastPort));
-          // Spin up a new thread to listen to this socket
-          new Thread(() => ListenSocket(socket)).Start();
-        }
-
-        try
-        {
-          // Wait until cancellation requested
-          await Task.Delay(Timeout.Infinite, cancellationToken);
-        }
-        catch (TaskCanceledException)
-        {
-          // Cancellation requested
-        }
-      }
-      finally
-      {
-        // Close socket (which will end thread) then dispose unmanaged resource
-        foreach (Socket socket in socketList)
-        {
-          socket.Close();
-          socket.Dispose();
-        }
-      }
-
-      return _discoveredBridges.Select(x => x.Value).ToList();
-    }
-
-    /// <summary>
-    /// Create a multicast socket for SSDP
-    /// </summary>
-    /// <param name="endpointToBind">the endpoint to bind to</param>
-    private Socket CreateSocketForSSDP(IPEndPoint endpointToBind)
-    {
-      Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
-
-      // Socket config : allow address reuse
-      socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
-
-      // Socket config : bind to all interface and to a port (if 0, ask for a free one)
-      socket.Bind(endpointToBind);
-
-      // Socket config : Add Multicast address membership to be able to send to it
-      socket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership, new MulticastOption(multicastAddress, IPAddress.Any));
-
-      return socket;
-    }
-
-    /// <summary>
-    /// Listen to response on socket
-    /// </summary>
-    /// <param name="socket">The socket to listen to</param>
-    private void ListenSocket(Socket socket)
-    {
-      try
-      {
-        var ipSeen = new List<string>();
-        while (true)
-        {
-          var responseRawBuffer = new byte[8000];
-          EndPoint responseEndPoint = new IPEndPoint(IPAddress.Any, multicastPort);
-          socket.ReceiveFrom(responseRawBuffer, ref responseEndPoint);
-
-          // We received a response
-          try
-          {
-            // Get IP address
-            IPAddress responseIpAddress = ((IPEndPoint)responseEndPoint).Address;
-
-            if (!ipSeen.Contains(responseIpAddress.ToString()))
-            {
-              // Try decode response as UTF8
-              var responseBody = Encoding.UTF8.GetString(responseRawBuffer);
-
-              if (!string.IsNullOrWhiteSpace(responseBody))
-              {
-                // Spin up a new thread to handle this specific response so we can continue waiting for response
-                new Thread(async () => await HandleSSDPResponseAsync(responseIpAddress).ConfigureAwait(false)).Start();
-
-                // Add this ip to local list, so we won't start other thread for it
-                ipSeen.Add(responseIpAddress.ToString());
-              }
-              else
-              {
-                // Not a valid response
-              }
-            }
-            else
-            {
-              // IP already seen
-            }
-          }
-          catch
-          {
-            // Something went wrong when parsing the response. Ignore it.
-          }
-        }
-      }
-      catch
-      {
-        // Socket connection closed, this will terminate the thread
-      }
-    }
-
-    /// <summary>
-    /// Handle a SSDP response
-    /// </summary>
-    /// <param name="ip">The IP that responded</param>
-    /// <param name="response">The response received</param>
-    private async Task HandleSSDPResponseAsync(IPAddress ip)
-    {
-      try
-      {
-        using (var ctsTimeout = new CancellationTokenSource(TimeSpan.FromMilliseconds(1000)))
-        {
-          // Check if it's a Hue Bridge
-          string serialNumber = await CheckHueDescriptor(ip, ctsTimeout.Token).ConfigureAwait(false);
-
-          if (!string.IsNullOrWhiteSpace(serialNumber))
-          {
-            _discoveredBridges.TryAdd(ip.ToString(), new LocatedBridge()
-            {
-              IpAddress = ip.ToString(),
-              BridgeId = serialNumber,
-            });
-          }
-          else
-          {
-            // Not a valid S/N
-          }
-        }
-      }
-      catch
-      {
-        // Something went wrong, ignore...
-      }
+      return await LocateBridgesAsync(ssdpMulticastAddress, ssdpMulticastPort, ssdpLocalPort, ssdpDiscoveryMessage, cancellationToken);
     }
   }
 }


### PR DESCRIPTION

Continuing #198 

The last one! The discovery using the M-DNS protocol `MdnsBridgeLocator`

I had some trouble making this one work, since the RFC are not that helpful sometimes.
And there are 2 related RFC : [the DNS one](https://tools.ietf.org/html/rfc1035) (specifiying the classic DNS request) and the [M-DNS one](https://tools.ietf.org/html/rfc6762) specifying the difference.

Hopefully, with a bit of Wireshark spying I was able to figure it out.

After coding the new locator, it occurs to me that the working was almost identical to the SSDP one, with only a different multicast address, port and message.

Since I strongly believe in DRY code, I went ahead and merged the behavior in a new abstract class `MUdpBasedBridgeLocator` for locators based on UDP multicast discovery.

Hope you like it, feel free to comment / ask for modification.