### PR TITLE
HttpClient fix for all locators

### DIFF
--- a/src/Q42.HueApi.Tests/BridgeDiscoveryTests.cs
+++ b/src/Q42.HueApi.Tests/BridgeDiscoveryTests.cs
@@ -43,6 +43,22 @@ namespace Q42.HueApi.Tests
       await TestBridgeLocatorWithTimeout(locator, TimeSpan.FromSeconds(5));
     }
 
+    [TestMethod]
+    public async Task TestParallelLocators()
+    {
+      IBridgeLocator httpBridgeLocator = new HttpBridgeLocator();
+      IBridgeLocator ssdpBridgeLocator = new SsdpBridgeLocator();
+      IBridgeLocator mdnsBridgeLocator = new MdnsBridgeLocator();
+      IBridgeLocator localNetworkScanBridgeLocator = new LocalNetworkScanBridgeLocator();
+
+      await Task.WhenAll(new Task[] {
+        TestBridgeLocatorWithTimeout(httpBridgeLocator, TimeSpan.FromSeconds(5)),
+        TestBridgeLocatorWithTimeout(ssdpBridgeLocator, TimeSpan.FromSeconds(5)),
+        TestBridgeLocatorWithTimeout(mdnsBridgeLocator, TimeSpan.FromSeconds(5)),
+        TestBridgeLocatorWithTimeout(localNetworkScanBridgeLocator, TimeSpan.FromSeconds(30)),
+      });
+    }
+
     private async Task TestBridgeLocatorWithTimeout(IBridgeLocator locator, TimeSpan timeout)
     {
       var startTime = DateTime.Now;

--- a/src/Q42.HueApi/HttpBridgeLocator.cs
+++ b/src/Q42.HueApi/HttpBridgeLocator.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -23,10 +22,8 @@ namespace Q42.HueApi
     /// <returns>List of bridge IPs found</returns>
     public override async Task<IEnumerable<LocatedBridge>> LocateBridgesAsync(CancellationToken cancellationToken)
     {
-      using (HttpClient client = new HttpClient())
+      using (var response = await _httpClient.GetAsync(NuPnPUrl, cancellationToken).ConfigureAwait(false))
       {
-        var response = await client.GetAsync(NuPnPUrl, cancellationToken).ConfigureAwait(false);
-
         if (response.IsSuccessStatusCode && !cancellationToken.IsCancellationRequested)
         {
           string content = await response.Content.ReadAsStringAsync();


### PR DESCRIPTION
Continuing #198 and the issue found by @d8ahazard  

This PR brings the following fixes:
* use a shared HttpClient to avoid socket exhaustion
 * dispose of HttpResponseMessage
 * Add discovery test with all locators running in parallel

The rational to use a shared HttpClient is from:

- https://aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/
- https://stackoverflow.com/questions/15705092/do-httpclient-and-httpclienthandler-have-to-be-disposed
- https://github.com/Azure/azure-functions-host/issues/1806

This is actually the way the `HueClient` class is built, with [either a shared HttpClient](https://github.com/Q42/Q42.HueApi/blob/master/src/Q42.HueApi/HueClient.cs#L65), or a [given one by the user in the constructor](https://github.com/Q42/Q42.HueApi/blob/master/src/Q42.HueApi/HueClient.cs#L43).

I choose not to change the `IBridgeLocator` signature for now and use a local common HttpClient. But if you want me to add a new constructor signature to match the `HueClient` class, feel free to ask.