### PR TITLE
Fixed gamut serialization in GamutConverter (fix for issue #211)

### DIFF
--- a/src/Q42.HueApi/Converters/GamutConverter.cs
+++ b/src/Q42.HueApi/Converters/GamutConverter.cs
@@ -68,7 +68,7 @@ namespace Q42.HueApi.Converters
 
       var result = new List<List<double>>() { red, green, blue };
 
-      writer.WriteValue(result);
+      serializer.Serialize(writer, result);
     }
   }
 }


### PR DESCRIPTION
I noticed similar errors as in https://github.com/Q42/Q42.HueApi/issues/211
Serializing Gamut results in error:

> JsonWriterException: Unsupported type: System.Collections.Generic.List`1[System.Collections.Generic.List`1[System.Double]]. Use the JsonSerializer class to get the object's JSON representation. 

This change fixes this.
