### PR TITLE
BridgeLocator: add event that is called when a bridge is found

### DIFF
--- a/src/Q42.HueApi/BridgeLocator.cs
+++ b/src/Q42.HueApi/BridgeLocator.cs
@@ -20,7 +20,28 @@ namespace Q42.HueApi
 
     private const string httpXmlDescriptorFileFormat = "http://{0}/description.xml";
 
-    protected readonly static HttpClient _httpClient = new HttpClient();
+    protected static readonly HttpClient _httpClient = new HttpClient();
+    
+    /// <summary>
+    /// Event handler in case a bridge was found
+    /// </summary>
+    /// <param name="sender">The source of the event</param>
+    /// <param name="locatedBridge">The bridge that was found</param>
+    public delegate void BridgeFoundHandler(IBridgeLocator sender, LocatedBridge locatedBridge);
+
+    /// <summary>
+    /// Event that is called when a bridge is found
+    /// </summary>
+    public event BridgeFoundHandler BridgeFound = (sender, bridge) => { };
+
+    /// <summary>
+    /// Calls the event that a bridge is found
+    /// </summary>
+    /// <param name="locatedBridge">The bridge that was found</param>
+    protected void OnBridgeFound(LocatedBridge locatedBridge)
+    {
+      BridgeFound(this, locatedBridge);
+    }
 
     /// <summary>
     /// Locate bridges

--- a/src/Q42.HueApi/HttpBridgeLocator.cs
+++ b/src/Q42.HueApi/HttpBridgeLocator.cs
@@ -30,7 +30,9 @@ namespace Q42.HueApi
 
           NuPnPResponse[] responseModel = JsonConvert.DeserializeObject<NuPnPResponse[]>(content);
 
-          return responseModel.Select(x => new LocatedBridge() { BridgeId = x.Id, IpAddress = x.InternalIpAddress }).ToList();
+          var locatedBridges = responseModel.Select(x => new LocatedBridge() { BridgeId = x.Id, IpAddress = x.InternalIpAddress }).ToList();
+          locatedBridges.ForEach(OnBridgeFound);
+          return locatedBridges;
         }
         else
         {

--- a/src/Q42.HueApi/LocalNetworkScanBridgeLocator.cs
+++ b/src/Q42.HueApi/LocalNetworkScanBridgeLocator.cs
@@ -57,11 +57,15 @@ namespace Q42.HueApi
 
               if (!string.IsNullOrEmpty(serialNumber))
               {
-                discoveredBridges.TryAdd(ip.ToString(), new LocatedBridge()
+                var locatedBridge = new LocatedBridge()
                 {
                   IpAddress = ip.ToString(),
                   BridgeId = serialNumber,
-                });
+                };
+                if (discoveredBridges.TryAdd(ip.ToString(), locatedBridge))
+                {
+                  OnBridgeFound(locatedBridge);
+                }
               }
               else
               {

--- a/src/Q42.HueApi/MUdpBasedBridgeLocator.cs
+++ b/src/Q42.HueApi/MUdpBasedBridgeLocator.cs
@@ -108,7 +108,7 @@ namespace Q42.HueApi
     /// </summary>
     /// <param name="socket">The socket to listen to</param>
     /// <param name="discoveredBridges">The dictionary to fill with located bridges</param>
-    private static void ListenSocketAndCheckEveryEndpoint(Socket socket, ConcurrentDictionary<string, LocatedBridge> discoveredBridges)
+    private void ListenSocketAndCheckEveryEndpoint(Socket socket, ConcurrentDictionary<string, LocatedBridge> discoveredBridges)
     {
       try
       {
@@ -146,11 +146,15 @@ namespace Q42.HueApi
 
                     if (!string.IsNullOrWhiteSpace(serialNumber))
                     {
-                      discoveredBridges.TryAdd(responseIpAddress.ToString(), new LocatedBridge()
+                      var locatedBridge = new LocatedBridge()
                       {
                         IpAddress = responseIpAddress.ToString(),
                         BridgeId = serialNumber,
-                      });
+                      };
+                      if (discoveredBridges.TryAdd(responseIpAddress.ToString(), locatedBridge))
+                      {
+                        OnBridgeFound(locatedBridge);
+                      }
                     }
                     else
                     {


### PR DESCRIPTION
This adds an event that is called when a bridge is found.

My use case is the following: I want to use the `SsdpBridgeLocator`.
I only have one bridge in use, so that as a result, this one is enough for me.
But with the current implementation, I have to wait all the time I have specified in the timeout, even though the bridge may already have been found.

With the event I can implement the following to speed things up:
```csharp
var locator = new SsdpBridgeLocator();
var cancelSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
locator.BridgeFound += (s, b) =>
{
	cancelSource.Cancel();
};
var bridges = (await locator.LocateBridgesAsync(cancelSource.Token));
```