### PR TITLE
Adding bridgeId to Remote Registration

### DIFF
--- a/src/Q42.HueApi/RemoteHueClient-Authentication.cs
+++ b/src/Q42.HueApi/RemoteHueClient-Authentication.cs
@@ -63,7 +63,7 @@ namespace Q42.HueApi
         var key = result["success"]?["username"]?.Value<string>();
         if (!string.IsNullOrEmpty(key))
         {
-          Initialize(key!);
+          Initialize(bridgeId!, key!);
 
           return key;
         }


### PR DESCRIPTION
Going through setting up Remote Api support for [PresenceLight](https://github.com/isaacrlevin/PresenceLight), it seems that calling RegisterAsync(string bridgeId,  string appId), the apiBase is not updated to have the registered bridge, so you have to make an unnecessary call to Initialize() afterwards. Adding bridgeId to RegisterAsync() should resolve this