### PR TITLE
Allow setting lightstates when creating scenes

### DIFF
--- a/src/Q42.HueApi/HueClient-Scenes.cs
+++ b/src/Q42.HueApi/HueClient-Scenes.cs
@@ -80,7 +80,6 @@ namespace Q42.HueApi
 			sceneJson.Remove("lastupdated");
 			sceneJson.Remove("locked");
 			sceneJson.Remove("owner");
-			sceneJson.Remove("lightstates");
 
 			string jsonString = JsonConvert.SerializeObject(sceneJson, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore });
 
@@ -177,7 +176,6 @@ namespace Q42.HueApi
 			sceneJson.Remove("lastupdated");
 			sceneJson.Remove("locked");
 			sceneJson.Remove("owner");
-			sceneJson.Remove("lightstates");
 
 			string jsonString = JsonConvert.SerializeObject(sceneJson, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore });
 


### PR DESCRIPTION
This fixes a small bug in the `CreateSceneAsync` and `UpdateSceneAsync` methods on the `HueClient`. The `lightstates` property was removed after serializing because according to the comment, it should not be settable. However, according to the documentation and my testing, it is possible (and in fact very useful) to set it.

With this PR, the property will no longer be ignored when creating/updating a scene.