### PR TITLE
Removed DataMember/added JsonIgnore attributes in Id properties in Hue models

### DIFF
--- a/src/Q42.HueApi/Models/Groups/Group.cs
+++ b/src/Q42.HueApi/Models/Groups/Group.cs
@@ -14,7 +14,6 @@ namespace Q42.HueApi.Models.Groups
 	[DataContract]
 	public class Group
 	{
-		[DataMember]
 		public string Id { get; set; }
 
 		[DataMember(Name = "name")]

--- a/src/Q42.HueApi/Models/Light.cs
+++ b/src/Q42.HueApi/Models/Light.cs
@@ -10,7 +10,6 @@ namespace Q42.HueApi
   [DataContract]
   public class Light
   {
-    [DataMember(Name = "id")]
     public string Id { get; set; }
 
     [DataMember(Name = "state")]

--- a/src/Q42.HueApi/Models/ResourceLink.cs
+++ b/src/Q42.HueApi/Models/ResourceLink.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -15,7 +15,6 @@ namespace Q42.HueApi.Models
 			Links = new List<string>();
 		}
 
-		[DataMember]
 		public string Id { get; set; }
 
 		/// <summary>

--- a/src/Q42.HueApi/Models/Scene.cs
+++ b/src/Q42.HueApi/Models/Scene.cs
@@ -13,7 +13,6 @@ namespace Q42.HueApi.Models
   [DataContract]
   public class Scene
   {
-    [DataMember]
     public string Id { get; set; }
 
     [DataMember(Name = "name")]

--- a/src/Q42.HueApi/Models/Schedule/Schedule.cs
+++ b/src/Q42.HueApi/Models/Schedule/Schedule.cs
@@ -9,7 +9,6 @@ namespace Q42.HueApi.Models
   [DataContract]
   public class Schedule
   {
-    [DataMember]
     public string Id { get; set; }
 
     [DataMember(Name = "name")]

--- a/src/Q42.HueApi/Models/Sensors/Sensor.cs
+++ b/src/Q42.HueApi/Models/Sensors/Sensor.cs
@@ -6,9 +6,6 @@ using Q42.HueApi.Models.Sensors.CLIP;
 using Q42.HueApi.Models.Sensors.ZigBee;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Q42.HueApi.Models
 {
@@ -38,7 +35,7 @@ namespace Q42.HueApi.Models
     [JsonProperty("capabilities")]
     public SensorCapabilities Capabilities { get; set; }
 
-    [JsonProperty("id")]
+    [JsonIgnore]
     public string Id { get; set; }
 
     [JsonProperty("manufacturername")]
@@ -197,11 +194,11 @@ namespace Q42.HueApi.Models
 
   public class SensorInput
   {
-	  [JsonProperty("repeatintervals")]
-	  public int[] RepeatIntervals { get; set; } = default!;
-	
-	  [JsonProperty("events")]
-	  public SensorEvent[] Events { get; set; } = default!;
+    [JsonProperty("repeatintervals")]
+    public int[] RepeatIntervals { get; set; } = default!;
+
+    [JsonProperty("events")]
+    public SensorEvent[] Events { get; set; } = default!;
   }
 
   public class SensorEvent

--- a/src/Q42.HueApi/Models/WhiteList.cs
+++ b/src/Q42.HueApi/Models/WhiteList.cs
@@ -8,7 +8,6 @@ namespace Q42.HueApi
   [DataContract]
   public class WhiteList
   {
-    [DataMember(Name = "id")]
     public string Id { get; set; }
 
     [DataMember(Name = "last use date")]


### PR DESCRIPTION
As far as I know, Hue never returns id in the object's body. Id is returned as a dictionary key and it is set in this library accordingly, for example in HueClient-Lights:
```
if (light != null)
  light.Id = id;
```
I use the models from this library to recreate Hue API, and DataMember/JsonProperty attributes on these properties results in incorrect responses. This change should correct this without affecting other use cases.